### PR TITLE
fix: unify Bitbucket REST API auth — always Basic email:token

### DIFF
--- a/agent/src/spawner.ts
+++ b/agent/src/spawner.ts
@@ -277,6 +277,7 @@ export interface ManagerCredentials {
   scmToken?: string;
   githubToken?: string;
   bitbucketUsername?: string;
+  bitbucketEmail?: string;
 }
 
 /**
@@ -329,6 +330,7 @@ export async function spawnManagerWorker(
     GH_TOKEN: githubToken,
     BITBUCKET_TOKEN: bitbucketToken,
     BITBUCKET_USERNAME: credentials?.bitbucketUsername || "x-bitbucket-api-token-auth",
+    BITBUCKET_EMAIL: credentials?.bitbucketEmail || "",
     GITLAB_TOKEN: gitlabToken,
 
     MANAGER_PROVIDER: credentials?.managerProvider || "",

--- a/worker/epic/executor.ts
+++ b/worker/epic/executor.ts
@@ -18,7 +18,7 @@ import type {
 } from "./types.js";
 import { getExpertConfig, COORDINATION_INSTRUCTIONS, LEARNING_INSTRUCTIONS } from "./experts.js";
 import { CoordinationClient } from "./coordination-client.js";
-import { GitOps } from "./git-ops.js";
+import { GitOps, getBitbucketAuthHeader } from "./git-ops.js";
 import { TicketOps } from "./ticket-ops.js";
 import { runAgent, type AgentOptions, type AgentResult } from "./agent-sdk.js";
 import { createAIClient, type AIClient, type AIClientOptions } from "./ai-client-types.js";
@@ -728,7 +728,7 @@ The same pattern applies to Redis, MongoDB, MySQL, etc. **Tests that pass locall
 
   /**
    * Poll Bitbucket Pipelines API for CI status.
-   * Uses Bearer token auth (Repository Access Token).
+   * Uses Basic auth with email:token (Bitbucket API tokens).
    */
   private async pollBitbucketPipelinesCI(
     workspace: string,
@@ -737,6 +737,7 @@ The same pattern applies to Redis, MongoDB, MySQL, etc. **Tests that pass locall
     expert: ExpertPersona
   ): Promise<{ passed: boolean; log?: string; summary: string; infrastructureFailure?: boolean }> {
     const token = process.env.SCM_TOKEN || process.env.BITBUCKET_TOKEN || this.config.githubToken;
+    const bitbucketAuth = getBitbucketAuthHeader(token);
     const maxWaitMs = 600_000;
     const pollIntervalMs = 10_000;
     const startTime = Date.now();
@@ -746,7 +747,7 @@ The same pattern applies to Redis, MongoDB, MySQL, etc. **Tests that pass locall
       try {
         const url = `https://api.bitbucket.org/2.0/repositories/${workspace}/${repoSlug}/pipelines/?target.branch=${encodeURIComponent(branchName)}&sort=-created_on&pagelen=1`;
         const response = await axios.get(url, {
-          headers: { Authorization: `Bearer ${token}` },
+          headers: { Authorization: bitbucketAuth },
           timeout: 15_000,
         });
 
@@ -768,7 +769,7 @@ The same pattern applies to Redis, MongoDB, MySQL, etc. **Tests that pass locall
             try {
               const stepsUrl = `https://api.bitbucket.org/2.0/repositories/${workspace}/${repoSlug}/pipelines/${pipeline.uuid}/steps/`;
               const stepsResp = await axios.get(stepsUrl, {
-                headers: { Authorization: `Bearer ${token}` },
+                headers: { Authorization: bitbucketAuth },
                 timeout: 15_000,
               });
               const failedSteps = (stepsResp.data?.values || [])

--- a/worker/epic/git-ops.ts
+++ b/worker/epic/git-ops.ts
@@ -17,20 +17,22 @@ const execFileAsync = promisify(execFile);
 
 /**
  * Build the correct Authorization header for Bitbucket API calls.
- * API Tokens (ATATT prefix) require email:token Basic auth.
- * Repository Access Tokens use Bearer auth.
+ *
+ * Bitbucket API tokens (the only supported credential type since app passwords
+ * were deprecated Sept 2025) require Basic auth with email:token.
+ * Git clone uses x-bitbucket-api-token-auth:{token} — but REST API calls
+ * MUST use the account email, not the git username.
  */
 export function getBitbucketAuthHeader(token: string): string {
   const bitbucketEmail = process.env.BITBUCKET_EMAIL;
 
-  // API Tokens (start with ATATT) require email:token Basic auth
-  if (bitbucketEmail) {
-    const credentials = Buffer.from(`${bitbucketEmail}:${token}`).toString("base64");
-    return `Basic ${credentials}`;
+  if (!bitbucketEmail) {
+    console.error("[Bitbucket] WARNING: BITBUCKET_EMAIL not set — API calls will fail. Bitbucket REST API requires Basic auth with email:token.");
   }
 
-  // Fallback to Bearer (for Repository Access Tokens)
-  return `Bearer ${token}`;
+  // Always Basic auth: email:token (or just :token if email missing — will 401 but with a clear log above)
+  const credentials = Buffer.from(`${bitbucketEmail || ""}:${token}`).toString("base64");
+  return `Basic ${credentials}`;
 }
 
 /**

--- a/worker/execution-compiled/git/create_pr.js
+++ b/worker/execution-compiled/git/create_pr.js
@@ -107,29 +107,18 @@ function exec(cmd, cwd, env) {
 /**
  * Build the correct Authorization header for Bitbucket API calls.
  *
- * Bitbucket authentication depends on the credential type:
- * - API Token (new format): Requires email:token Basic auth for API calls
- *   - Git clone uses x-bitbucket-api-token-auth:<token>
- *   - API calls use Basic auth with email:token (NOT x-bitbucket-api-token-auth!)
- * - App Password (legacy): Uses username:password Basic auth for both git and API
- * - Repository Access Token: Uses Bearer token
+ * Bitbucket API tokens require Basic auth with email:token.
+ * Git clone uses x-bitbucket-api-token-auth:{token} — but REST API calls
+ * MUST use the account email, not the git username.
+ * App passwords were deprecated Sept 2025.
  */
-function getBitbucketAuthHeader(username, token) {
-    // Check for email in environment (passed by orchestrator for API token format)
+function getBitbucketAuthHeader(token) {
     const bitbucketEmail = process.env.BITBUCKET_EMAIL;
-    if (bitbucketEmail) {
-        // API Token format: API calls require email:token Basic auth
-        const credentials = Buffer.from(`${bitbucketEmail}:${token}`).toString("base64");
-        return `Basic ${credentials}`;
+    if (!bitbucketEmail) {
+        console.error("[create_pr] WARNING: BITBUCKET_EMAIL not set — Bitbucket REST API requires Basic auth with email:token.");
     }
-    // Check if this looks like an app password scenario (username is not x-token-auth)
-    if (username && username !== "x-token-auth" && username !== "x-bitbucket-api-token-auth") {
-        // App Password format: use username:token
-        const credentials = Buffer.from(`${username}:${token}`).toString("base64");
-        return `Basic ${credentials}`;
-    }
-    // Fallback: Repository Access Token uses Bearer auth
-    return `Bearer ${token}`;
+    const credentials = Buffer.from(`${bitbucketEmail || ""}:${token}`).toString("base64");
+    return `Basic ${credentials}`;
 }
 /**
  * Create a PR using Bitbucket REST API
@@ -153,7 +142,7 @@ async function createBitbucketPR(workspace, repoSlug, title, sourceBranch, destB
         close_source_branch: false,
     });
     // Get the appropriate auth header based on credential type
-    const authHeader = getBitbucketAuthHeader(username, token);
+    const authHeader = getBitbucketAuthHeader(token);
     return new Promise((resolve, reject) => {
         const url = new URL(apiUrl);
         const options = {
@@ -203,7 +192,7 @@ async function createBitbucketPR(workspace, repoSlug, title, sourceBranch, destB
 async function findExistingBitbucketPR(workspace, repoSlug, sourceBranch, username, token) {
     const apiUrl = `https://api.bitbucket.org/2.0/repositories/${workspace}/${repoSlug}/pullrequests?q=source.branch.name="${sourceBranch}"&state=OPEN`;
     // Get the appropriate auth header based on credential type
-    const authHeader = getBitbucketAuthHeader(username, token);
+    const authHeader = getBitbucketAuthHeader(token);
     return new Promise((resolve, reject) => {
         const url = new URL(apiUrl);
         const options = {

--- a/worker/execution/git/create_pr.ts
+++ b/worker/execution/git/create_pr.ts
@@ -108,32 +108,20 @@ interface BitbucketPrResponse {
 /**
  * Build the correct Authorization header for Bitbucket API calls.
  *
- * Bitbucket authentication depends on the credential type:
- * - API Token (new format): Requires email:token Basic auth for API calls
- *   - Git clone uses x-bitbucket-api-token-auth:<token>
- *   - API calls use Basic auth with email:token (NOT x-bitbucket-api-token-auth!)
- * - App Password (legacy): Uses username:password Basic auth for both git and API
- * - Repository Access Token: Uses Bearer token
+ * Bitbucket API tokens require Basic auth with email:token.
+ * Git clone uses x-bitbucket-api-token-auth:{token} — but REST API calls
+ * MUST use the account email, not the git username.
+ * App passwords were deprecated Sept 2025.
  */
-function getBitbucketAuthHeader(username: string, token: string): string {
-  // Check for email in environment (passed by orchestrator for API token format)
+function getBitbucketAuthHeader(token: string): string {
   const bitbucketEmail = process.env.BITBUCKET_EMAIL;
 
-  if (bitbucketEmail) {
-    // API Token format: API calls require email:token Basic auth
-    const credentials = Buffer.from(`${bitbucketEmail}:${token}`).toString("base64");
-    return `Basic ${credentials}`;
+  if (!bitbucketEmail) {
+    console.error("[create_pr] WARNING: BITBUCKET_EMAIL not set — Bitbucket REST API requires Basic auth with email:token.");
   }
 
-  // Check if this looks like an app password scenario (username is not x-token-auth)
-  if (username && username !== "x-token-auth" && username !== "x-bitbucket-api-token-auth") {
-    // App Password format: use username:token
-    const credentials = Buffer.from(`${username}:${token}`).toString("base64");
-    return `Basic ${credentials}`;
-  }
-
-  // Fallback: Repository Access Token uses Bearer auth
-  return `Bearer ${token}`;
+  const credentials = Buffer.from(`${bitbucketEmail || ""}:${token}`).toString("base64");
+  return `Basic ${credentials}`;
 }
 
 /**
@@ -169,7 +157,7 @@ async function createBitbucketPR(
   });
 
   // Get the appropriate auth header based on credential type
-  const authHeader = getBitbucketAuthHeader(username, token);
+  const authHeader = getBitbucketAuthHeader(token);
 
   return new Promise((resolve, reject) => {
     const url = new URL(apiUrl);
@@ -227,7 +215,7 @@ async function findExistingBitbucketPR(
   const apiUrl = `https://api.bitbucket.org/2.0/repositories/${workspace}/${repoSlug}/pullrequests?q=source.branch.name="${sourceBranch}"&state=OPEN`;
 
   // Get the appropriate auth header based on credential type
-  const authHeader = getBitbucketAuthHeader(username, token);
+  const authHeader = getBitbucketAuthHeader(token);
 
   return new Promise((resolve, reject) => {
     const url = new URL(apiUrl);

--- a/worker/multi-expert/index.ts
+++ b/worker/multi-expert/index.ts
@@ -168,32 +168,20 @@ function loadConfig(): MultiExpertConfig {
 /**
  * Build the correct Authorization header for Bitbucket API calls.
  *
- * Bitbucket authentication depends on the credential type:
- * - API Token (new format): Requires email:token Basic auth for API calls
- *   - Git clone uses x-bitbucket-api-token-auth:<token>
- *   - API calls use Basic auth with email:token (NOT x-bitbucket-api-token-auth!)
- * - App Password (legacy): Uses username:password Basic auth for both git and API
- * - Repository Access Token: Uses Bearer token
+ * Bitbucket API tokens require Basic auth with email:token.
+ * Git clone uses x-bitbucket-api-token-auth:{token} — but REST API calls
+ * MUST use the account email, not the git username.
+ * App passwords were deprecated Sept 2025.
  */
-function getBitbucketAuthHeader(username: string, token: string): string {
-  // Check for email in environment (passed by orchestrator for API token format)
+function getBitbucketAuthHeader(token: string): string {
   const bitbucketEmail = process.env.BITBUCKET_EMAIL;
 
-  if (bitbucketEmail) {
-    // API Token format: API calls require email:token Basic auth
-    const credentials = Buffer.from(`${bitbucketEmail}:${token}`).toString("base64");
-    return `Basic ${credentials}`;
+  if (!bitbucketEmail) {
+    console.error("[Bitbucket] WARNING: BITBUCKET_EMAIL not set — Bitbucket REST API requires Basic auth with email:token.");
   }
 
-  // Check if this looks like an app password scenario (username is not x-token-auth)
-  if (username && username !== "x-token-auth" && username !== "x-bitbucket-api-token-auth") {
-    // App Password format: use username:token
-    const credentials = Buffer.from(`${username}:${token}`).toString("base64");
-    return `Basic ${credentials}`;
-  }
-
-  // Fallback: Repository Access Token uses Bearer auth
-  return `Bearer ${token}`;
+  const credentials = Buffer.from(`${bitbucketEmail || ""}:${token}`).toString("base64");
+  return `Basic ${credentials}`;
 }
 
 /**
@@ -1320,7 +1308,7 @@ export class MultiExpertCoordinator {
     });
 
     // Get the appropriate auth header based on credential type
-    const authHeader = getBitbucketAuthHeader(username, token);
+    const authHeader = getBitbucketAuthHeader(token);
 
     return new Promise((resolve, reject) => {
       const url = new URL(apiUrl);
@@ -1387,7 +1375,7 @@ export class MultiExpertCoordinator {
     const apiUrl = `https://api.bitbucket.org/2.0/repositories/${workspace}/${repoSlug}/pullrequests?q=source.branch.name="${sourceBranch}"&state=OPEN`;
 
     // Get the appropriate auth header based on credential type
-    const authHeader = getBitbucketAuthHeader(username, token);
+    const authHeader = getBitbucketAuthHeader(token);
 
     return new Promise((resolve, reject) => {
       const url = new URL(apiUrl);


### PR DESCRIPTION
## Summary

- Removed Bearer token fallback from all Bitbucket REST API auth paths — Bitbucket API tokens require `Basic email:token`, Bearer only works for Repository Access Tokens which we don't use
- Fixed `pollBitbucketPipelinesCI` in executor.ts which was hardcoding `Bearer` for Bitbucket API calls
- Added missing `BITBUCKET_EMAIL` env var to native spawner (only docker-spawner had it)
- Unified `getBitbucketAuthHeader` across git-ops.ts, create_pr.ts, and multi-expert/index.ts — same signature, same behavior, clear warning when email is missing

## Test plan

- [ ] Run a Bitbucket task end-to-end (planning + execution + PR creation)
- [ ] Verify PR creation succeeds with `Basic email:token` auth
- [ ] Verify CI polling works for Bitbucket Pipelines repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)